### PR TITLE
Update shard.yml to point to releases of deps

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -2,11 +2,11 @@ version: 2.0
 shards:
   cluster_tools:
     git: https://github.com/cnf-testsuite/cluster_tools.git
-    version: 0.1.0+git.commit.9541c11aedd688b6c03386f83fd2a89756fbedae
+    version: 1.0.0
 
   docker_client:
     git: https://github.com/cnf-testsuite/docker_client.git
-    version: 0.1.0+git.commit.394f8652859ae635f0504fe9134f96f40975db3c
+    version: 1.0.0
 
   find:
     git: https://github.com/cnf-testsuite/find.git
@@ -18,15 +18,15 @@ shards:
 
   helm:
     git: https://github.com/cnf-testsuite/helm.git
-    version: 0.1.0+git.commit.12b1152fcb8d55806d6c5949716a1ff116c4d3d2
+    version: 1.0.1
 
   kernel_introspection:
     git: https://github.com/cnf-testsuite/kernel_introspection.git
-    version: 0.1.0+git.commit.a267babbb77bcab877ded6895f9416854a11a67b
+    version: 0.1.0
 
   kubectl_client:
     git: https://github.com/cnf-testsuite/kubectl_client.git
-    version: 0.1.0+git.commit.12cad24a372469e34e0f64019b10e1b3dc82a124
+    version: 1.0.1
 
   popcorn:
     git: https://github.com/icyleaf/popcorn.git

--- a/shard.yml
+++ b/shard.yml
@@ -16,15 +16,14 @@ targets:
 dependencies:
   kubectl_client:
     github: cnf-testsuite/kubectl_client
-    branch: main
+    version: ~> 1.0.0
   kernel_introspection:
     github: cnf-testsuite/kernel_introspection
-    branch: main
+    version: ~> 1.0.0
   cluster_tools:
     # path: ../cluster_tools
     github: cnf-testsuite/cluster_tools
-    branch: main
+    version: ~> 1.0.0
   helm:
     github: cnf-testsuite/helm
-    branch: main
-
+    version: ~> 1.0.0

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: k8s_netstat
-version: 0.1.0
+version: 1.0.0
 
 authors:
   - W. Watson <Watson@vulk.coop>

--- a/shard.yml
+++ b/shard.yml
@@ -19,7 +19,7 @@ dependencies:
     version: ~> 1.0.0
   kernel_introspection:
     github: cnf-testsuite/kernel_introspection
-    version: ~> 1.0.0
+    version: ~> 0.1.0
   cluster_tools:
     # path: ../cluster_tools
     github: cnf-testsuite/cluster_tools


### PR DESCRIPTION
This is to help with cncf/cnf-testsuite#1751.

This updates the versions of all dependencies to `~> 1.0.0`