### PR TITLE
Hotfix: Increase netstat attempts from 10 to 30

### DIFF
--- a/src/netstat/k8s.cr
+++ b/src/netstat/k8s.cr
@@ -112,7 +112,7 @@ module Netstat
       Log.info { "Container PID: #{pid}" }
 
       # get multiple call for a larger sample
-      parsed_netstat = (1..10).map {
+      parsed_netstat = (1..30).map {
         sleep 10
         netstat = ClusterTools.exec_by_node("nsenter -t #{pid} -n netstat -n", node_name)
         Log.info { "Container Netstat: #{netstat}" }


### PR DESCRIPTION
A quickfix for [#2078](https://github.com/cnti-testcatalog/testsuite/issues/2078) from testsuite.

This obviously increases the time spent running netstat commands (as they execute every 10 seconds) but for the time being I think that it will not matter all that much. A full refactor will be necessary in the future as the current logic does not allow for a proper solution (like breaking the loop in case two violators have already been found) - I will write a ticket for that.